### PR TITLE
Bug fix: MBF-FAT32 mode not working on /dev/loop0

### DIFF
--- a/windows2usb
+++ b/windows2usb
@@ -244,7 +244,7 @@ then
         mkfs.vfat -n "${isolabel:0:11}" "$(get_dev_partition_num "${dev}" "1")"
 
         echo "${bold} == Writing bootloader ==${normal}"
-        ms-sys -7 "${dev}"
+        ms-sys -7 -f "${dev}"
         ms-sys -e "$(get_dev_partition_num "${dev}" "1")"
 
         echo "${bold} == Mounting data partition ==${normal}"


### PR DESCRIPTION
While running `windows2usb /dev/loop0 xxx.iso mbr`, we're getting this error: 

```
 == Writing bootloader ==
/dev/loop0 seems to be a disk partition device,
use the switch -f to force writing of a master boot record
```